### PR TITLE
traefik: add support for custom request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v4.1.0](https://github.com/containeroo/SyncFlaer/tree/v4.1.0) (2021-06-11)
+
+[All Commits](https://github.com/containeroo/SyncFlaer/compare/v4.0.1...v4.1.0)
+
+**New features:**
+
+- add ability to set custom request headers on Traefik request
+
 ## [v4.0.1](https://github.com/containeroo/SyncFlaer/tree/v4.0.1) (2021-05-11)
 
 [All Commits](https://github.com/containeroo/SyncFlaer/compare/v4.0.0...v4.0.1)

--- a/README.md
+++ b/README.md
@@ -166,21 +166,27 @@ traefikInstances:
     url: https://traefik1.example.com
     user: admin1
     password: supersecure
+    customRequestHeaders:
+      X-Example-Header: instance1
     ignoredRules:
       - instance1.example.com
   - name: instance2
     url: https://traefik2.example.com
     user: admin2
     password: stillsupersecure
+    customRequestHeaders:
+      Authorization: env:TREAFIK_AUTH_HEADER
     ignoredRules:
       - instance2.example.com
 ```
 
-You can configure HTTP basic auth and a list of rules to be ignored for each instance individually.
+Every instance can be configured to use different HTTP basic auth, custom request headers and ignored rules.
 
 If you want to use an environment variable for the HTTP basic auth password, the environment variable must be named `TRAEFIK_<INSTANCE_NAME>_PASSWORD`.
 
 In this example, the two environment variables would be `TRAEFIK_INSTANCE1_PASSWORD` and `TRAEFIK_INSTANCE2_PASSWORD`.
+
+The `customRequestHeader` `Authorization` for Traefik "instance2" will use the contents of `TRAEFIK_AUTH_HEADER` environment variable.
 
 #### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ SyncFlaer must be configured via a [YAML config file](#full-config-file). Some s
 
 #### Minimal Config File
 
-The following configuration is required.
+The following configuration is required:
 
 ```yaml
 ---
@@ -107,6 +107,13 @@ traefikInstances:
     # HTTP basic auth credentials for Traefik
     username: admin
     password: supersecure  # can also be set using TRAEFIK_MAIN_PASSWORD env variable
+    # you can set http headers that will be added to the Traefik api request
+    # requires string keys and string values
+    customRequestHeaders:
+      # headers can either be key value pairs in plain text
+      X-Example-Header: Example-Value
+      # or the value can be imported from env variables using the 'env:' prefix
+      Authorization: env:MY_AUTH_VAR  # in this case $MY_AUTH_VAR env variable will be used as the value
     # a list of rules which will be ignored
     # these rules are matched as a substring of the entire Traefik rule (i.e test.local.example.com would also match)
     ignoredRules:
@@ -238,7 +245,7 @@ Select the following settings:
 
 2021 Containeroo
 
-Cloudflare and the Cloudflare Logo are registered trademarks owned by Cloudflare Inc.
+Cloudflare and the Cloudflare logo are registered trademarks owned by Cloudflare Inc.
 This project is not affiliated with Cloudflare®.
 
 ## License

--- a/cmd/syncflaer/main.go
+++ b/cmd/syncflaer/main.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "4.0.1"
+const version string = "4.1.0"
 
 func main() {
 	log.SetOutput(os.Stdout)

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -22,6 +22,13 @@ traefikInstances:
     # HTTP basic auth credentials for Traefik
     username: admin
     password: supersecure  # can also be set using TRAEFIK_MAIN_PASSWORD env variable
+    # you can set http headers that will be added to the Traefik api request
+    # requires string keys and string values
+    customRequestHeaders:
+      # headers can either be key value pairs in plain text
+      X-Example-Header: Example-Value
+      # or the value can be imported from env variables using the 'env:' prefix
+      Authorization: env:MY_AUTH_VAR  # in this case $MY_AUTH_VAR env variable will be used as the value
     # a list of rules which will be ignored
     # these rules are matched as a substring of the entire Traefik rule (i.e test.local.example.com would also match)
     ignoredRules:

--- a/internal/config.go
+++ b/internal/config.go
@@ -65,8 +65,8 @@ func GetConfig(configFilePath string) Configuration {
 		config.TraefikInstances[i].Password = os.Getenv(envName)
 
 		for k, v := range traefikInstance.CustomRequestHeaders {
-			if strings.Contains(v, "env:") {
-				config.TraefikInstances[i].CustomRequestHeaders[k] = os.Getenv(strings.ReplaceAll(v, "env:", ""))
+			if strings.HasPrefix(v, "env:") {
+				config.TraefikInstances[i].CustomRequestHeaders[k] = os.Getenv(strings.Replace(v, "env:", "", 1))
 			}
 		}
 	}

--- a/internal/traefik.go
+++ b/internal/traefik.go
@@ -62,6 +62,9 @@ func GetTraefikRules(zoneName string, userRecords []cloudflare.DNSRecord) []clou
 		if traefikInstance.Username != "" && traefikInstance.Password != "" {
 			req.SetBasicAuth(traefikInstance.Username, traefikInstance.Password)
 		}
+		for k, v := range traefikInstance.CustomRequestHeaders {
+			req.Header.Add(k, v)
+		}
 		resp, err := client.Do(req)
 		if err != nil {
 			log.Fatalf("Unable to get Traefik (%s) rules: %s", traefikInstance.Name, err)


### PR DESCRIPTION
this pr adds the ability to configure custom request headers for the Traefik api request.

Todo:

- [x] test code
- [x] document changes