### PR TITLE
add dynamic env naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v5.0.0](https://github.com/containeroo/SyncFlaer/tree/v5.0.0) (2021-06-??)
+## [v5.0.0](https://github.com/containeroo/SyncFlaer/tree/v5.0.0) (2021-06-17)
 
 [All Commits](https://github.com/containeroo/SyncFlaer/compare/v4.1.1...v5.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v5.0.0](https://github.com/containeroo/SyncFlaer/tree/v5.0.0) (2021-06-??)
+
+[All Commits](https://github.com/containeroo/SyncFlaer/compare/v4.1.1...v5.0.0)
+
+**Caution!** The configuration has been changed since v4.1.1! Please refer to the readme file for more information.
+
+**Improvements:**
+
+- add ability to dynamically configure environment variables for Cloudflare API token, Slack token URL and Traefik HTTP basic auth password using the `env:` prefix in config file
+
 ## [v4.1.1](https://github.com/containeroo/SyncFlaer/tree/v4.1.1) (2021-06-13)
 
 [All Commits](https://github.com/containeroo/SyncFlaer/compare/v4.1.0...v4.1.1)

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Select the following settings:
 ### From 4.x to 5.x
 
 The `cloudflare.apiToken` config is now required to be present in config file.  
-Environment variable names for Slack webhook URL, Traefik HTTP basic auth password and Cloudflare API token must be defined in config file by using the `env:` prefix.
+If you want to use environment variables for Slack webhook URL, Traefik HTTP basic auth password and Cloudflare API token, you have to use the `env:` prefix.
 Everything after the `env:` part will be used as the name of the env variable.
 
 ## Copyright

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ Instead of putting secrets in the config file, SyncFlaer can grab secrets from e
 
 You can define the names of the environment variables by using the `env:` prefix. For example:
 
-| Configuration                                 | Example                   |
-|-----------------------------------------------|---------------------------|
-| `notifications.slack.webhookURL`              | `env:SLACK_TOKEN`         |
-| `traefikInstances.[].password`                | `env:TRAEFIK_K8S_PW`      |
-| `traefikInstances.[].customRequestHeaders.[]` | `env:TRAEFIK_AUTH_HEADER` |
-| `cloudflare.apiToken`                         | `env:CF_API_TOKEN`        |
+| Configuration                                | Example                   |
+|----------------------------------------------|---------------------------|
+| `notifications.slack.webhookURL`             | `env:SLACK_TOKEN`         |
+| `password` in `traefikInstances`             | `env:TRAEFIK_K8S_PW`      |
+| `customRequestHeaders` in `traefikInstances` | `env:TRAEFIK_AUTH_HEADER` |
+| `cloudflare.apiToken`                        | `env:CF_API_TOKEN`        |
 
 #### Defaults
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Synchronize Traefik host rules with Cloudflare®.
     - [Example A Record](#example-a-record)
     - [Example CNAME Record](#example-cname-record)
   - [Cloudflare API Token](#cloudflare-api-token)
+- [Upgrade Notes](#upgrade-notes)
+  - [From 4.x to 5.x](#from-4x-to-5x)
 - [Copyright](#copyright)
 - [License](#license)
 
@@ -165,7 +167,7 @@ cloudflare:
 
 #### Using Multiple Traefik Instances
 
-Starting with version 2.0.0, you can configure SyncFlaer to gather host rules from multiple Traefik instances.  
+You can configure SyncFlaer to gather host rules from multiple Traefik instances.  
 The configuration for two instances would look like this:
 
 ```yaml
@@ -194,7 +196,7 @@ Every instance can be configured to use different HTTP basic auth, custom reques
 
 Instead of putting secrets in the config file, SyncFlaer can grab secrets from environment variables.
 
-You can define the names of the environment variables by using the `env:` prefix. For example:
+You can define the names of the environment variables by using the `env:` prefix.
 
 | Configuration                                | Example                   |
 |----------------------------------------------|---------------------------|
@@ -251,6 +253,14 @@ Select the following settings:
 
 **Zone Resources:**  
 - `Include` - `All Zones`
+
+## Upgrade Notes
+
+### From 4.x to 5.x
+
+The `cloudflare.apiToken` config is now required to be present in config file.  
+Environment variable names for Slack webhook URL, Traefik HTTP basic auth password and Cloudflare API token must be defined in config file by using the `env:` prefix.
+Everything after the `env:` part will be used as the name of the env variable.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ syncflaer --config-path /opt/syncflaer.yml
 Flags:
 
 ```text
-Usage of SyncFlaer:
   -c, --config-path string   Path to config file (default "config.yml")
   -d, --debug                Enable debug mode
   -v, --version              Print the current version and exit
@@ -73,7 +72,7 @@ traefikInstances:
     url: https://traefik.example.com
 
 cloudflare:
-  apiToken: abc  # can also be set using CLOUDFLARE_APITOKEN env variable
+  apiToken: abc  # can also be set using an env variable
   zoneNames:
     - example.com
   defaults:
@@ -94,7 +93,7 @@ ipProviders:
 notifications:
   slack:
     # Slack webhook URL
-    webhookURL: https://hooks.slack.com/services/abc/def  # can also be set using SLACK_WEBHOOK env variable
+    webhookURL: https://hooks.slack.com/services/abc/def  # can also be set using an env variable (e.g. env:SLACK_TOKEN)
     username: SyncFlaer
     channel: "#syncflaer"
     iconURL: https://url.to/image.png
@@ -106,7 +105,7 @@ traefikInstances:
     url: https://traefik.example.com
     # HTTP basic auth credentials for Traefik
     username: admin
-    password: supersecure  # can also be set using TRAEFIK_MAIN_PASSWORD env variable
+    password: supersecure  # can also be set using an env variable by setting the value to 'env:ENV_VAR_NAME' (e.g. env:TRAEFIK_FIRST_PW)
     # you can set http headers that will be added to the Traefik api request
     # requires string keys and string values
     customRequestHeaders:
@@ -123,7 +122,7 @@ traefikInstances:
   - name: secondary
     url: https://traefik-secondary.example.com
     username: admin
-    password: stillsupersecure  # can also be set using TRAEFIK_SECONDARY_PASSWORD env variable
+    password: stillsupersecure  # can also be set using an env variable by setting the value to 'env:ENV_VAR_NAME' (e.g. env:TRAEFIK_TWO_PW)
     ignoredRules:
       - example.example.com
       - internal.example.com
@@ -140,7 +139,7 @@ additionalRecords:
 
 cloudflare:
   # global Cloudflare API token
-  apiToken: abc  # can also be set using CLOUDFLARE_APITOKEN env variable
+  apiToken: abc  # can also be set using an env variable (e.g. env:CF_API_TOKEN)
   # a list of Cloudflare zone names
   zoneNames:
     - example.com
@@ -182,21 +181,18 @@ traefikInstances:
 
 Every instance can be configured to use different HTTP basic auth, custom request headers and ignored rules.
 
-If you want to use an environment variable for the HTTP basic auth password, the environment variable must be named `TRAEFIK_<INSTANCE_NAME>_PASSWORD`.
-
-In this example, the two environment variables would be `TRAEFIK_INSTANCE1_PASSWORD` and `TRAEFIK_INSTANCE2_PASSWORD`.
-
-The `customRequestHeader` `Authorization` for Traefik "instance2" will use the contents of `TRAEFIK_AUTH_HEADER` environment variable.
-
 #### Environment Variables
 
-**Note:** Environment variables have a higher precedence than the config file!
+Instead of putting secrets in the config file, SyncFlaer can grab secrets from environment variables.
 
-| Name                               | Description                                      |
-|------------------------------------|--------------------------------------------------|
-| `SLACK_WEBHOOK`                    | Slack Webhook URL                                |
-| `TRAEFIK_<INSTANCE_NAME>_PASSWORD` | Password for Traefik dashboard (HTTP basic auth) |
-| `CLOUDFLARE_APITOKEN`              | Cloudflare API token                             |
+You can define the environment variables by using the `env:` prefix. For example:
+
+| Configuration                                 | Example                   |
+|-----------------------------------------------|---------------------------|
+| `notifications.slack.webhookURL`              | `env:SLACK_TOKEN`         |
+| `traefikInstances.[].password`                | `env:TRAEFIK_K8S_PW`      |
+| `traefikInstances.[].customRequestHeaders.[]` | `env:TRAEFIK_AUTH_HEADER` |
+| `cloudflare.apiToken`                         | `env:CF_API_TOKEN`        |
 
 #### Defaults
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ traefikInstances:
     url: https://traefik.example.com
 
 cloudflare:
-  apiToken: abc  # can also be set using an env variable
+  apiToken: abc
   zoneNames:
     - example.com
   defaults:
@@ -93,7 +93,10 @@ ipProviders:
 notifications:
   slack:
     # Slack webhook URL
-    webhookURL: https://hooks.slack.com/services/abc/def  # can also be set using an env variable (e.g. env:SLACK_TOKEN)
+    # you can set the value directly in config file
+    webhookURL: https://hooks.slack.com/services/abc/def
+    # or by using an env variable by using the 'env:' prefix
+    # webhookURL: env:SLACK_WEBHOOK_URL  # in this case the contents of $SLACK_WEBHOOK_URL env variable will be used as the value
     username: SyncFlaer
     channel: "#syncflaer"
     iconURL: https://url.to/image.png
@@ -105,14 +108,17 @@ traefikInstances:
     url: https://traefik.example.com
     # HTTP basic auth credentials for Traefik
     username: admin
-    password: supersecure  # can also be set using an env variable by setting the value to 'env:ENV_VAR_NAME' (e.g. env:TRAEFIK_FIRST_PW)
+    # you can set the value directly in config file
+    password: supersecure
+    # or by using an env variable using the 'env:' prefix
+    # password: env:TRAEFIK_PW  # in this case the contents of $TRAEFIK_PW env variable will be used as the value
     # you can set http headers that will be added to the Traefik api request
     # requires string keys and string values
     customRequestHeaders:
       # headers can either be key value pairs in plain text
       X-Example-Header: Example-Value
       # or the value can be imported from env variables using the 'env:' prefix
-      Authorization: env:MY_AUTH_VAR  # in this case $MY_AUTH_VAR env variable will be used as the value
+      Authorization: env:MY_AUTH_VAR  # in this case the contents of $MY_AUTH_VAR env variable will be used as the value
     # a list of rules which will be ignored
     # these rules are matched as a substring of the entire Traefik rule (i.e test.local.example.com would also match)
     ignoredRules:
@@ -122,7 +128,7 @@ traefikInstances:
   - name: secondary
     url: https://traefik-secondary.example.com
     username: admin
-    password: stillsupersecure  # can also be set using an env variable by setting the value to 'env:ENV_VAR_NAME' (e.g. env:TRAEFIK_TWO_PW)
+    password: stillsupersecure
     ignoredRules:
       - example.example.com
       - internal.example.com
@@ -139,7 +145,10 @@ additionalRecords:
 
 cloudflare:
   # global Cloudflare API token
-  apiToken: abc  # can also be set using an env variable (e.g. env:CF_API_TOKEN)
+  # you can set the value directly in config file
+  apiToken: abc
+  # or by using an env variable using the 'env:' prefix
+  # apiToken: env:CF_API_TOKEN  # in this case the contents of $CF_API_TOKEN env variable will be used as the value
   # a list of Cloudflare zone names
   zoneNames:
     - example.com

--- a/cmd/syncflaer/main.go
+++ b/cmd/syncflaer/main.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "4.1.1"
+const version string = "5.0.0"
 
 func main() {
 	log.SetOutput(os.Stdout)

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -9,7 +9,7 @@ ipProviders:
 notifications:
   slack:
     # Slack webhook URL
-    webhookURL: https://hooks.slack.com/services/abc/def  # can also be set using SLACK_WEBHOOK env variable
+    webhookURL: https://hooks.slack.com/services/abc/def  # can also be set using an env variable (e.g. env:SLACK_TOKEN)
     username: SyncFlaer
     channel: "#syncflaer"
     iconURL: https://url.to/image.png
@@ -21,7 +21,7 @@ traefikInstances:
     url: https://traefik.example.com
     # HTTP basic auth credentials for Traefik
     username: admin
-    password: supersecure  # can also be set using TRAEFIK_MAIN_PASSWORD env variable
+    password: supersecure  # can also be set using an env variable by setting the value to 'env:ENV_VAR_NAME' (e.g. env:TRAEFIK_FIRST_PW)
     # you can set http headers that will be added to the Traefik api request
     # requires string keys and string values
     customRequestHeaders:
@@ -38,7 +38,7 @@ traefikInstances:
   - name: secondary
     url: https://traefik-secondary.example.com
     username: admin
-    password: stillsupersecure  # can also be set using TRAEFIK_SECONDARY_PASSWORD env variable
+    password: stillsupersecure  # can also be set using an env variable by setting the value to 'env:ENV_VAR_NAME' (e.g. env:TRAEFIK_TWO_PW)
     ignoredRules:
       - example.example.com
       - internal.example.com
@@ -55,7 +55,7 @@ additionalRecords:
 
 cloudflare:
   # global Cloudflare API token
-  apiToken: abc  # can also be set using CLOUDFLARE_APITOKEN env variable
+  apiToken: abc  # can also be set using an env variable (e.g. env:CF_API_TOKEN)
   # a list of Cloudflare zone names
   zoneNames:
     - example.com

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -9,7 +9,10 @@ ipProviders:
 notifications:
   slack:
     # Slack webhook URL
-    webhookURL: https://hooks.slack.com/services/abc/def  # can also be set using an env variable (e.g. env:SLACK_TOKEN)
+    # you can set the value directly in config file
+    webhookURL: https://hooks.slack.com/services/abc/def
+    # or by using an env variable by using the 'env:' prefix
+    # webhookURL: env:SLACK_WEBHOOK_URL  # in this case the contents of $SLACK_WEBHOOK_URL env variable will be used as the value
     username: SyncFlaer
     channel: "#syncflaer"
     iconURL: https://url.to/image.png
@@ -21,14 +24,17 @@ traefikInstances:
     url: https://traefik.example.com
     # HTTP basic auth credentials for Traefik
     username: admin
-    password: supersecure  # can also be set using an env variable by setting the value to 'env:ENV_VAR_NAME' (e.g. env:TRAEFIK_FIRST_PW)
+    # you can set the value directly in config file
+    password: supersecure
+    # or by using an env variable using the 'env:' prefix
+    # password: env:TRAEFIK_PW  # in this case the contents of $TRAEFIK_PW env variable will be used as the value
     # you can set http headers that will be added to the Traefik api request
     # requires string keys and string values
     customRequestHeaders:
       # headers can either be key value pairs in plain text
       X-Example-Header: Example-Value
       # or the value can be imported from env variables using the 'env:' prefix
-      Authorization: env:MY_AUTH_VAR  # in this case $MY_AUTH_VAR env variable will be used as the value
+      Authorization: env:MY_AUTH_VAR  # in this case the contents of $MY_AUTH_VAR env variable will be used as the value
     # a list of rules which will be ignored
     # these rules are matched as a substring of the entire Traefik rule (i.e test.local.example.com would also match)
     ignoredRules:
@@ -38,7 +44,7 @@ traefikInstances:
   - name: secondary
     url: https://traefik-secondary.example.com
     username: admin
-    password: stillsupersecure  # can also be set using an env variable by setting the value to 'env:ENV_VAR_NAME' (e.g. env:TRAEFIK_TWO_PW)
+    password: stillsupersecure
     ignoredRules:
       - example.example.com
       - internal.example.com
@@ -55,7 +61,10 @@ additionalRecords:
 
 cloudflare:
   # global Cloudflare API token
-  apiToken: abc  # can also be set using an env variable (e.g. env:CF_API_TOKEN)
+  # you can set the value directly in config file
+  apiToken: abc
+  # or by using an env variable using the 'env:' prefix
+  # apiToken: env:CF_API_TOKEN  # in this case the contents of $CF_API_TOKEN env variable will be used as the value
   # a list of Cloudflare zone names
   zoneNames:
     - example.com

--- a/deployments/kubernetes/configmap.yaml
+++ b/deployments/kubernetes/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   config.yml: |
     ---
+    notifications:
+      slack:
+        webhookURL: env:SLACK_WEBHOOK_URL
     traefikInstances:
       - name: main
         url: https://traefik.example.com
@@ -19,6 +22,7 @@ data:
         proxied: false
 
     cloudflare:
+      apiToken: env:CF_API_TOKEN
       zoneNames:
         - example.com
       deleteGrace: 5

--- a/deployments/kubernetes/secret.yaml
+++ b/deployments/kubernetes/secret.yaml
@@ -5,5 +5,5 @@ metadata:
   name: syncflaer
 type: Opaque
 stringData:
-  SLACK_WEBHOOK: https://hooks.slack.com/services/abc/def
-  CLOUDFLARE_APITOKEN: abc
+  SLACK_WEBHOOK_URL: https://hooks.slack.com/services/abc/def
+  CF_API_TOKEN: abc


### PR DESCRIPTION
this pr adds the ability to dynamically configure the name of env vars using the `env:` prefix in config file.

this will be a major release since it breaks current configs.

todo:

- [x] test code
- [x] add documentation