### PR TITLE
Fix root domain route handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v5.1.3](https://github.com/containeroo/SyncFlaer/tree/v5.1.3) (2021-10-25)
+
+[All Commits](https://github.com/containeroo/SyncFlaer/compare/v5.1.2...v5.1.3)
+
+**Bug fixes:**
+
+- fix an issue that caused an error if a Traefik route was equal to the root domain (e.g. `example.com`)
+
+**Dependencies:**
+
+- Update module github.com/slack-go/slack to v0.9.5 (#74)
+- Update module github.com/cloudflare/cloudflare-go to v0.26.0 (#76)
+
 ## [v5.1.2](https://github.com/containeroo/SyncFlaer/tree/v5.1.2) (2021-09-06)
 
 [All Commits](https://github.com/containeroo/SyncFlaer/compare/v5.1.1...v5.1.2)

--- a/internal/traefik.go
+++ b/internal/traefik.go
@@ -101,6 +101,9 @@ func GetTraefikRules(zoneName string, userRecords []cloudflare.DNSRecord) []clou
 			}
 			matches := re.FindAllStringSubmatch(router.Rule, -1)
 			for _, match := range matches {
+				if match[0] == zoneName {
+					continue
+				}
 				if !checkDuplicateRule(match[0], userRecords) {
 					for _, ignoredRule := range traefikInstance.IgnoredRules {
 						if strings.Contains(match[0], ignoredRule) {


### PR DESCRIPTION
fixes an issue if a Traefik route was equal to the root domain:

```
Unable to update DNS record example.com: HTTP status 400: CNAME content cannot reference itself. (9039)
```