### PR TITLE
Add ability to disable root record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v5.2.0](https://github.com/containeroo/SyncFlaer/tree/v5.2.0) (2021-12-23)
+
+[All Commits](https://github.com/containeroo/SyncFlaer/compare/v5.1.6...v5.2.0)
+
+**New features:**
+
+- add ability to disable management of the root record (#89)
+
+**New default settings:**
+
+- the `proxied` field in additionalRecords and Cloudflare defaults is no longer required and defaults to `true` if omitted
+
 ## [v5.1.6](https://github.com/containeroo/SyncFlaer/tree/v5.1.6) (2021-12-14)
 
 [All Commits](https://github.com/containeroo/SyncFlaer/compare/v5.1.5...v5.1.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v5.2.0](https://github.com/containeroo/SyncFlaer/tree/v5.2.0) (2021-12-23)
+## [v5.2.0](https://github.com/containeroo/SyncFlaer/tree/v5.2.0) (2021-12-24)
 
 [All Commits](https://github.com/containeroo/SyncFlaer/compare/v5.1.6...v5.2.0)
 

--- a/README.md
+++ b/README.md
@@ -77,93 +77,11 @@ cloudflare:
   apiToken: abc
   zoneNames:
     - example.com
-  defaults:
-    proxied: true
 ```
 
 #### Full Config File
 
-```yaml
----
-# a list of services that return the public IP
-ipProviders:
-  - https://ifconfig.me/ip
-  - https://ipecho.net/plain
-  - https://myip.is/ip
-
-# configure Slack notifications for SyncFlaer
-notifications:
-  slack:
-    # Slack webhook URL
-    # you can set the value directly in config file
-    webhookURL: https://hooks.slack.com/services/abc/def
-    # or by using an environment variable by using the 'env:' prefix
-    # webhookURL: env:SLACK_WEBHOOK_URL  # in this case the contents of $SLACK_WEBHOOK_URL environment variable will be used as the value
-    username: SyncFlaer
-    channel: "#syncflaer"
-    iconURL: https://url.to/image.png
-
-traefikInstances:
-    # the name of the Traefik instance
-  - name: main
-    # base URL for Traefik dashboard and API (https://doc.traefik.io/traefik/operations/api/)
-    url: https://traefik.example.com
-    # HTTP basic auth credentials for Traefik
-    username: admin
-    # you can set the value directly in config file
-    password: supersecure
-    # or by using an environment variable using the 'env:' prefix
-    # password: env:TRAEFIK_PW  # in this case the contents of $TRAEFIK_PW environment variable will be used as the value
-    # you can set http headers that will be added to the Traefik api request
-    # requires string keys and string values
-    customRequestHeaders:
-      # headers can either be key value pairs in plain text
-      X-Example-Header: Example-Value
-      # or the value can be imported from environment variables using the 'env:' prefix
-      Authorization: env:MY_AUTH_VAR  # in this case the contents of $MY_AUTH_VAR environment variable will be used as the value
-    # a list of rules which will be ignored
-    # these rules are matched as a substring of the entire Traefik rule (i.e test.local.example.com would also match)
-    ignoredRules:
-      - local.example.com
-      - dev.example.com
-    # you can add a second instance
-  - name: secondary
-    url: https://traefik-secondary.example.com
-    username: admin
-    password: stillsupersecure
-    ignoredRules:
-      - example.example.com
-      - internal.example.com
-
-# specify additional DNS records for services absent in Traefik (i.e. vpn server)
-additionalRecords:
-  - name: vpn.example.com
-    ttl: 120
-    proxied: false
-  - name: a.example.com
-    proxied: true
-    type: A
-    contents: 1.1.1.1
-
-cloudflare:
-  # global Cloudflare API token
-  # you can set the value directly in config file
-  apiToken: abc
-  # or by using an environment variable using the 'env:' prefix
-  # apiToken: env:CF_API_TOKEN  # in this case the contents of $CF_API_TOKEN environment variable will be used as the value
-  # a list of Cloudflare zone names
-  zoneNames:
-    - example.com
-    - othersite.com
-  # define how many skips should happen until a DNS record gets deleted
-  # every run of SyncFlaer counts as a skip
-  deleteGrace: 5
-  # define a set of defaults applied to all Traefik rules
-  defaults:
-    type: CNAME
-    proxied: true
-    ttl: 1
-```
+The full configuration file can be found at `configs/config.yml`.
 
 #### Using Multiple Traefik Instances
 
@@ -213,7 +131,9 @@ If not specified, the following defaults apply:
 |--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | `ipProviders`                  | `["https://ifconfig.me/ip", "https://ipecho.net/plain", "https://myip.is/ip", "https://checkip.amazonaws.com", "https://api.ipify.org"]` |
 | `cloudflare.deleteGrace`       | `0` (delete records instantly)                                                                                                           |
+| `managedRootRecord`            | `true`                                                                                                                                   |
 | `cloudflare.defaults.type`     | `CNAME`                                                                                                                                  |
+| `cloudflare.defaults.proxied`  | `true`                                                                                                                                   |
 | `cloudflare.defaults.ttl`      | `1`                                                                                                                                      |
 | `notifications.slack.username` | `SyncFlaer`                                                                                                                              |
 | `notifications.slack.iconURL`  | `https://www.cloudflare.com/img/cf-facebook-card.png`                                                                                    |
@@ -230,7 +150,7 @@ You can specify additional DNS records which are not configured as Traefik hosts
 | `type`    | `A`             | `cloudflare.defaults.type` | no       |
 | `ttl`     | `1`             | `cloudflare.defaults.ttl`  | no       |
 | `content` | `1.1.1.1`       | `current public IP`        | no       |
-| `proxied` | `true`          | none                       | yes      |
+| `proxied` | `true`          | `true`                     | no       |
 
 #### Example CNAME Record
 
@@ -240,7 +160,7 @@ You can specify additional DNS records which are not configured as Traefik hosts
 | `type`    | `CNAME`           | `cloudflare.defaults.type` | no       |
 | `ttl`     | `120`             | `cloudflare.defaults.ttl`  | no       |
 | `content` | `mysite.com`      | `cloudflare.zoneName`      | no       |
-| `proxied` | `false`           | none                       | yes      |
+| `proxied` | `false`           | `true`                     | no       |
 
 ### Cloudflare API Token
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ If not specified, the following defaults apply:
 | Name                           | Default Value                                                                                                                            |
 |--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | `ipProviders`                  | `["https://ifconfig.me/ip", "https://ipecho.net/plain", "https://myip.is/ip", "https://checkip.amazonaws.com", "https://api.ipify.org"]` |
-| `cloudflare.deleteGrace`       | `0` (delete records instantly)                                                                                                           |
 | `managedRootRecord`            | `true`                                                                                                                                   |
+| `cloudflare.deleteGrace`       | `0` (delete records instantly)                                                                                                           |
 | `cloudflare.defaults.type`     | `CNAME`                                                                                                                                  |
 | `cloudflare.defaults.proxied`  | `true`                                                                                                                                   |
 | `cloudflare.defaults.ttl`      | `1`                                                                                                                                      |
@@ -144,23 +144,23 @@ You can specify additional DNS records which are not configured as Traefik hosts
 
 #### Example A Record
 
-| Key       | Example         | Default Value              | Required |
-|-----------|-----------------|----------------------------|----------|
-| `name`    | `a.example.com` | none                       | yes      |
-| `type`    | `A`             | `cloudflare.defaults.type` | no       |
-| `ttl`     | `1`             | `cloudflare.defaults.ttl`  | no       |
-| `content` | `1.1.1.1`       | `current public IP`        | no       |
-| `proxied` | `true`          | `true`                     | no       |
+| Key       | Example         | Default Value                 | Required |
+|-----------|-----------------|-------------------------------|----------|
+| `name`    | `a.example.com` | none                          | yes      |
+| `type`    | `A`             | `cloudflare.defaults.type`    | no       |
+| `ttl`     | `1`             | `cloudflare.defaults.ttl`     | no       |
+| `proxied` | `true`          | `cloudflare.defaults.proxied` | no       |
+| `content` | `1.1.1.1`       | `current public IP`           | no       |
 
 #### Example CNAME Record
 
-| Key       | Example           | Default Value              | Required |
-|-----------|-------------------|----------------------------|----------|
-| `name`    | `vpn.example.com` | none                       | yes      |
-| `type`    | `CNAME`           | `cloudflare.defaults.type` | no       |
-| `ttl`     | `120`             | `cloudflare.defaults.ttl`  | no       |
-| `content` | `mysite.com`      | `cloudflare.zoneName`      | no       |
-| `proxied` | `false`           | `true`                     | no       |
+| Key       | Example           | Default Value                 | Required |
+|-----------|-------------------|-------------------------------|----------|
+| `name`    | `vpn.example.com` | none                          | yes      |
+| `type`    | `CNAME`           | `cloudflare.defaults.type`    | no       |
+| `ttl`     | `120`             | `cloudflare.defaults.ttl`     | no       |
+| `proxied` | `false`           | `cloudflare.defaults.proxied` | no       |
+| `content` | `mysite.com`      | `cloudflare.zoneName`         | no       |
 
 ### Cloudflare API Token
 

--- a/cmd/syncflaer/main.go
+++ b/cmd/syncflaer/main.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "5.1.6"
+const version string = "5.2.0"
 
 func main() {
 	log.SetOutput(os.Stdout)

--- a/cmd/syncflaer/main.go
+++ b/cmd/syncflaer/main.go
@@ -79,7 +79,7 @@ func main() {
 			log.Debug("No orphaned DNS records")
 		}
 
-		internal.CleanupDeleteGraceRecords(zoneName, zoneID, userRecords, cloudflareDNSRecords, deleteGraceRecords)
+		internal.CleanupDeleteGraceRecords(zoneID, userRecords, cloudflareDNSRecords, deleteGraceRecords)
 
 		internal.UpdateCloudflareDNSRecords(zoneID, cloudflareDNSRecords, userRecords)
 	}

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -49,6 +49,11 @@ traefikInstances:
       - example.example.com
       - internal.example.com
 
+# set whether you want to have the root record managed by SyncFlaer
+# if you don't need a root record, you can set this to false
+# it is also helpful to set this to false if your root record points to a different server
+managedRootRecord: true
+
 # specify additional DNS records for services absent in Traefik (i.e. vpn server)
 additionalRecords:
   - name: vpn.example.com
@@ -72,7 +77,7 @@ cloudflare:
   # define how many skips should happen until a DNS record gets deleted
   # every run of SyncFlaer counts as a skip
   deleteGrace: 5
-  # define a set of defaults applied to all Traefik rules
+  # define a set of defaults applied to all DNS records
   defaults:
     type: CNAME
     proxied: true

--- a/internal/additionalRecords.go
+++ b/internal/additionalRecords.go
@@ -43,17 +43,23 @@ additionalRecords:
 		if additionalRecord.TTL == 0 {
 			additionalRecord.TTL = 1
 		}
+		if additionalRecord.Proxied == nil {
+			additionalRecord.Proxied = config.Cloudflare.Defaults.Proxied
+		}
 		userRecords = append(userRecords, additionalRecord)
 		additionalRecordNames = append(additionalRecordNames, additionalRecord.Name)
 	}
-	rootDNSRecord := cloudflare.DNSRecord{
-		Type:    "A",
-		Name:    zoneName,
-		Content: currentIP,
-		Proxied: config.Cloudflare.Defaults.Proxied,
-		TTL:     config.Cloudflare.Defaults.TTL,
+	if *config.ManagedRootRecord {
+		rootDNSRecord := cloudflare.DNSRecord{
+			Type:    "A",
+			Name:    zoneName,
+			Content: currentIP,
+			Proxied: config.Cloudflare.Defaults.Proxied,
+			TTL:     config.Cloudflare.Defaults.TTL,
+		}
+		userRecords = append(userRecords, rootDNSRecord)
 	}
-	userRecords = append(userRecords, rootDNSRecord)
+
 	log.Debugf("Found additional DNS records: %s", strings.Join(additionalRecordNames, ", "))
 
 	return userRecords

--- a/internal/cloudflare.go
+++ b/internal/cloudflare.go
@@ -229,7 +229,7 @@ func UpdateDeleteGraceRecord(zoneID string, deleteGraceRecord cloudflare.DNSReco
 	log.Infof("Waiting %s more runs until DNS record %s gets deleted", deleteGraceRecord.Content, orphanedRecordName)
 }
 
-func CleanupDeleteGraceRecords(zoneName, zoneID string, userRecords, cloudflareDNSRecords, deleteGraceRecords []cloudflare.DNSRecord) {
+func CleanupDeleteGraceRecords(zoneID string, userRecords, cloudflareDNSRecords, deleteGraceRecords []cloudflare.DNSRecord) {
 	for _, deleteGraceRecord := range deleteGraceRecords {
 		dnsRecordFound := false
 		var dnsRecordName string

--- a/internal/cloudflare.go
+++ b/internal/cloudflare.go
@@ -234,9 +234,6 @@ func CleanupDeleteGraceRecords(zoneName, zoneID string, userRecords, cloudflareD
 		dnsRecordFound := false
 		var dnsRecordName string
 		for _, userRecord := range userRecords {
-			if userRecord.Name == zoneName {
-				continue
-			}
 			if deleteGraceRecord.Name == fmt.Sprintf("%s.%s", deleteGraceRecordPrefix, userRecord.Name) {
 				dnsRecordFound = true
 				dnsRecordName = userRecord.Name
@@ -249,9 +246,6 @@ func CleanupDeleteGraceRecords(zoneName, zoneID string, userRecords, cloudflareD
 			continue
 		}
 		for _, cloudflareDNSRecord := range cloudflareDNSRecords {
-			if cloudflareDNSRecord.Name == zoneName {
-				continue
-			}
 			if deleteGraceRecord.Name == fmt.Sprintf("%s.%s", deleteGraceRecordPrefix, cloudflareDNSRecord.Name) {
 				dnsRecordFound = true
 				break
@@ -261,6 +255,5 @@ func CleanupDeleteGraceRecords(zoneName, zoneID string, userRecords, cloudflareD
 			DeleteCloudflareDNSRecord(zoneID, deleteGraceRecord)
 			log.Debugf("Cleaned up delete grace DNS record %s", deleteGraceRecord.Name)
 		}
-
 	}
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -32,6 +32,7 @@ type Configuration struct {
 		CustomRequestHeaders map[string]string `yaml:"customRequestHeaders"`
 		IgnoredRules         []string          `yaml:"ignoredRules"`
 	} `yaml:"traefikInstances"`
+	ManagedRootRecord *bool                  `yaml:"managedRootRecord"`
 	AdditionalRecords []cloudflare.DNSRecord `yaml:"additionalRecords"`
 	Cloudflare        struct {
 		APIToken    string   `yaml:"apiToken"`
@@ -98,6 +99,17 @@ func GetConfig(configFilePath string) Configuration {
 	}
 
 	// Set default values
+	trueVar := true
+	if config.Cloudflare.Defaults.Proxied == nil {
+		config.Cloudflare.Defaults.Proxied = &trueVar
+		log.Debugf("Cloudflare default proxied is empty, defaulting to %t", *config.Cloudflare.Defaults.Proxied)
+	}
+
+	if config.ManagedRootRecord == nil {
+		config.ManagedRootRecord = &trueVar
+		log.Debugf("ManagedRootRecord is not set, defaulting to %t", *config.ManagedRootRecord)
+	}
+
 	if config.Cloudflare.Defaults.Type == "" {
 		config.Cloudflare.Defaults.Type = "CNAME"
 		log.Debugf("Cloudflare default type is empty, defaulting to %s", config.Cloudflare.Defaults.Type)

--- a/internal/config.go
+++ b/internal/config.go
@@ -100,11 +100,6 @@ func GetConfig(configFilePath string) Configuration {
 
 	// Set default values
 	trueVar := true
-	if config.Cloudflare.Defaults.Proxied == nil {
-		config.Cloudflare.Defaults.Proxied = &trueVar
-		log.Debugf("Cloudflare default proxied is empty, defaulting to %t", *config.Cloudflare.Defaults.Proxied)
-	}
-
 	if config.ManagedRootRecord == nil {
 		config.ManagedRootRecord = &trueVar
 		log.Debugf("ManagedRootRecord is not set, defaulting to %t", *config.ManagedRootRecord)
@@ -113,6 +108,11 @@ func GetConfig(configFilePath string) Configuration {
 	if config.Cloudflare.Defaults.Type == "" {
 		config.Cloudflare.Defaults.Type = "CNAME"
 		log.Debugf("Cloudflare default type is empty, defaulting to %s", config.Cloudflare.Defaults.Type)
+	}
+
+	if config.Cloudflare.Defaults.Proxied == nil {
+		config.Cloudflare.Defaults.Proxied = &trueVar
+		log.Debugf("Cloudflare default proxied is empty, defaulting to %t", *config.Cloudflare.Defaults.Proxied)
 	}
 
 	if config.Cloudflare.Defaults.TTL == 0 || *config.Cloudflare.Defaults.Proxied {


### PR DESCRIPTION
Fixes #89 

This pr adds the ability to disable the root record using `managedRootRecord` config.
If omitted, it will be set to true.

This pr also removed some previously required config settings:
- the `proxied` field is no longer required in additionalRecords and Cloudflare defaults since we can check if the content is `nil`
