### PR TITLE
Fix typo in example config

### DIFF
--- a/configs/config.yml
+++ b/configs/config.yml
@@ -82,7 +82,7 @@ additionalRecords:
   - name: a.example.com
     proxied: true
     type: A
-    contents: 1.1.1.1
+    content: 1.1.1.1
 
 cloudflare:
   # global Cloudflare API token


### PR DESCRIPTION
additional DNS records did not work because the example config contained a wrong attribute name.

See https://github.com/cloudflare/cloudflare-go/blob/9f773b1d9314071e2b5545f45454b6100193fe29/dns.go#L19 for reference
